### PR TITLE
Remove explicit deps from BUILD files, rely on pants inference

### DIFF
--- a/carbon_monitoring_service/src/BUILD
+++ b/carbon_monitoring_service/src/BUILD
@@ -1,10 +1,5 @@
 python_sources(
     sources=["**/*.py", "!contracts.py"],
-    dependencies=[
-        "lambda_common",
-        ":carbon_monitoring_contracts",
-        "//:reqs#icoscp"
-    ]
 )
 
 python_sources(

--- a/carbon_monitoring_service/src/entry_points/BUILD
+++ b/carbon_monitoring_service/src/entry_points/BUILD
@@ -1,8 +1,4 @@
-python_sources(
-    dependencies=[
-        "carbon_monitoring_service/src"
-    ]
-)
+python_sources()
 
 python_aws_lambda_function(
     name="get_latest_submissions_lambda",

--- a/carbon_monitoring_service/tests/BUILD
+++ b/carbon_monitoring_service/tests/BUILD
@@ -4,16 +4,6 @@ python_sources(
 
 python_tests(
     name="test_suite",
-    dependencies=[
-        "pyight_bdd",
-        "carbon_monitoring_service/src",
-        "carbon_monitoring_service/src/entry_points",
-        "lambda_common",
-        "//:reqs#responses",
-        "//:reqs#assertpy",
-        "//:reqs#moto",
-        "//:reqs#pytest"
-    ],
     sources=[
         "**/*_feature.py",
         "**/*_tests.py"

--- a/lambda_common/BUILD
+++ b/lambda_common/BUILD
@@ -1,9 +1,4 @@
-python_sources(
-    dependencies=[
-        "//:reqs#loguru",
-        "//:reqs#boto3-stubs"
-    ]
-)
+python_sources()
 
 python_aws_lambda_layer(
     name="common_layer",


### PR DESCRIPTION
Pants auto-infers Python dependencies from import statements. The explicit `dependencies` lists in `python_sources` and `python_tests` targets were redundant — pants already discovers them by reading imports.

**What changed:**
- `carbon_monitoring_service/src/BUILD` — removed `lambda_common`, `:carbon_monitoring_contracts`, `//:reqs#icoscp`
- `carbon_monitoring_service/src/entry_points/BUILD` — removed `carbon_monitoring_service/src`
- `carbon_monitoring_service/tests/BUILD` — removed all 8 explicit deps from `python_tests`
- `lambda_common/BUILD` — removed `loguru` and `boto3-stubs`

**What stayed:**
- Lambda packaging targets (`python_aws_lambda_function`, `python_aws_lambda_layer`) keep their explicit deps — these tell pants what code to bundle, not what to import
- Terraform targets unchanged — no inference support there