### PR TITLE
chore: rely on Pants auto-inference instead of manual BUILD deps

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,11 @@
 
 python_requirements(
     name="reqs",
-    source="pyproject.toml"
+    source="pyproject.toml",
+    module_mapping={
+        "boto3-stubs": ["mypy_boto3_dynamodb"],
+        "icoscp": ["icoscp_core"],
+    },
 )
 
 files(

--- a/carbon_monitoring_service/src/BUILD
+++ b/carbon_monitoring_service/src/BUILD
@@ -1,10 +1,5 @@
 python_sources(
     sources=["**/*.py", "!contracts.py"],
-    dependencies=[
-        "lambda_common",
-        ":carbon_monitoring_contracts",
-        "//:reqs#icoscp"
-    ]
 )
 
 python_sources(

--- a/carbon_monitoring_service/src/entry_points/BUILD
+++ b/carbon_monitoring_service/src/entry_points/BUILD
@@ -1,8 +1,4 @@
-python_sources(
-    dependencies=[
-        "carbon_monitoring_service/src"
-    ]
-)
+python_sources()
 
 python_aws_lambda_function(
     name="get_latest_submissions_lambda",

--- a/carbon_monitoring_service/tests/BUILD
+++ b/carbon_monitoring_service/tests/BUILD
@@ -4,16 +4,6 @@ python_sources(
 
 python_tests(
     name="test_suite",
-    dependencies=[
-        "pyight_bdd",
-        "carbon_monitoring_service/src",
-        "carbon_monitoring_service/src/entry_points",
-        "lambda_common",
-        "//:reqs#responses",
-        "//:reqs#assertpy",
-        "//:reqs#moto",
-        "//:reqs#pytest"
-    ],
     sources=[
         "**/*_feature.py",
         "**/*_tests.py"

--- a/lambda_common/BUILD
+++ b/lambda_common/BUILD
@@ -1,9 +1,4 @@
-python_sources(
-    dependencies=[
-        "//:reqs#loguru",
-        "//:reqs#boto3-stubs"
-    ]
-)
+python_sources()
 
 python_aws_lambda_layer(
     name="common_layer",


### PR DESCRIPTION
Removes explicit `dependencies` lists from `python_sources` and `python_tests` targets throughout the repo. Pants infers these from import statements at build time, so manual dependency wiring was redundant.

The only additions are `module_mapping` entries in the root `BUILD` for packages where the installable package name differs from the top-level import module:
- `boto3-stubs` → `mypy_boto3_dynamodb`
- `icoscp` → `icoscp_core`

Closes #3