### PR TITLE
chore: rely on Pants auto-inference instead of manual BUILD deps

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,11 @@
 
 python_requirements(
     name="reqs",
-    source="pyproject.toml"
+    source="pyproject.toml",
+    module_mapping={
+        "boto3-stubs": ["mypy_boto3_dynamodb"],
+        "icoscp": ["icoscp_core"],
+    },
 )
 
 files(

--- a/carbon_monitoring_service/src/BUILD
+++ b/carbon_monitoring_service/src/BUILD
@@ -1,10 +1,5 @@
 python_sources(
     sources=["**/*.py", "!contracts.py"],
-    dependencies=[
-        "lambda_common",
-        ":carbon_monitoring_contracts",
-        "//:reqs#icoscp"
-    ]
 )
 
 python_sources(

--- a/carbon_monitoring_service/src/entry_points/BUILD
+++ b/carbon_monitoring_service/src/entry_points/BUILD
@@ -1,8 +1,4 @@
-python_sources(
-    dependencies=[
-        "carbon_monitoring_service/src"
-    ]
-)
+python_sources()
 
 python_aws_lambda_function(
     name="get_latest_submissions_lambda",

--- a/carbon_monitoring_service/tests/BUILD
+++ b/carbon_monitoring_service/tests/BUILD
@@ -4,6 +4,9 @@ python_sources(
 
 python_tests(
     name="test_suite",
+    dependencies=[
+        "carbon_monitoring_service/src/entry_points",
+    ],
     sources=[
         "**/*_feature.py",
         "**/*_tests.py"

--- a/carbon_monitoring_service/tests/BUILD
+++ b/carbon_monitoring_service/tests/BUILD
@@ -4,16 +4,6 @@ python_sources(
 
 python_tests(
     name="test_suite",
-    dependencies=[
-        "pyight_bdd",
-        "carbon_monitoring_service/src",
-        "carbon_monitoring_service/src/entry_points",
-        "lambda_common",
-        "//:reqs#responses",
-        "//:reqs#assertpy",
-        "//:reqs#moto",
-        "//:reqs#pytest"
-    ],
     sources=[
         "**/*_feature.py",
         "**/*_tests.py"

--- a/lambda_common/BUILD
+++ b/lambda_common/BUILD
@@ -1,9 +1,4 @@
-python_sources(
-    dependencies=[
-        "//:reqs#loguru",
-        "//:reqs#boto3-stubs"
-    ]
-)
+python_sources()
 
 python_aws_lambda_layer(
     name="common_layer",


### PR DESCRIPTION
## Summary

- Removes explicit `dependencies=[]` from all BUILD files — pants automatically links targets when it detects imports
- Adds `module_mapping` to root BUILD for packages where the import name differs from the package name (`boto3-stubs` → `mypy_boto3_dynamodb`, `icoscp` → `icoscp_core`)
- Cleans up pyproject.toml (ruff/pyright config) and updates the lock file

## Test plan

- [ ] `pants test ::` passes
- [ ] `pants lint ::` passes
- [ ] `pants check ::` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)